### PR TITLE
Refresh dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mk20d7"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Dylan Frankland <dylan@frankland.io>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Peripheral access API for MK20D7 microcontrollers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ name = "mk20d7"
 path = "./src/lib.rs"
 
 [dependencies]
-bare-metal = "0.2.0"
-cortex-m = "0.5.2"
-vcell = "0.1.0"
+bare-metal = "1.0.0"
+cortex-m = "0.7.3"
+vcell = "0.1.3"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.5.1"
+version = "0.7.0"
 
 [features]
 rt = ["cortex-m-rt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,7 +426,7 @@ pub enum Interrupt {
     #[doc = "91 - PORTE"]
     PORTE,
 }
-unsafe impl ::bare_metal::Nr for Interrupt {
+unsafe impl ::cortex_m::interrupt::Nr for Interrupt {
     #[inline]
     fn nr(&self) -> u8 {
         match *self {
@@ -1706,7 +1706,6 @@ impl Deref for MCM {
 }
 #[doc = "Core Platform Miscellaneous Control Module"]
 pub mod mcm;
-#[allow(private_no_mangle_statics)]
 #[no_mangle]
 static mut DEVICE_PERIPHERALS: bool = false;
 #[doc = r" All the peripherals"]


### PR DESCRIPTION
I also have an update for mk20d7-hal to match this, but would require a release of this crate I believe. (My current changes in *-hal uses a local checkout of this repo)

Tested using `cargo build` and after updating mk20d7-hal using a script like:
```
        let mut gpioc = device.PTC.split(&device.SIM.scgc5);
        let mut led = gpioc.ptc5.into_push_pull_output(&mut gpioc.pcr, &mut gpioc.pddr);
```